### PR TITLE
feat: support domain name for EXTERNAL_IP in self-hosted server

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# 强制 shell 脚本使用 LF 换行，避免 Windows 上 CRLF 导致容器内脚本无法执行（bad interpreter）
+docker/start.sh text eol=lf
+docker/generate_certs.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ sudo docker run -d \
 上述命令中，用户需注意的参数如下：
 
 **参数**
-- EXTERNAL_IP：服务器公网 IP , 对应 CrossDesk 客户端**自托管服务器配置**中填写的**服务器地址**
-- INTERNAL_IP：服务器内网 IP
+- EXTERNAL_IP：服务器公网 IP **或域名**，对应 CrossDesk 客户端**自托管服务器配置**中填写的**服务器地址**。填域名（如 `desk.example.com`）时，容器启动时会自动把域名解析为 IP 注入 TURN 的 `external-ip`（ICE 候选仍需 IP），证书则以 `DNS:` 形式写入 SAN，客户端据此信任该域名。
+- INTERNAL_IP：服务器内网 IP（绑定地址，必须是 IP，不能是域名）
 - CROSSDESK_SERVER_PORT：自托管服务使用的端口，对应 CrossDesk 客户端**自托管服务器配置**中填写的**服务器端口**
 - COTURN_PORT: COTURN 服务使用的端口, 对应 CrossDesk 客户端**自托管服务器配置**中填写的**中继服务端口**
 - MIN_PORT/MAX_PORT：COTURN 服务使用的端口范围，例如：MIN_PORT=50000, MAX_PORT=60000，范围可根据客户端数量调整。
@@ -114,6 +114,29 @@ sudo docker run -d \
 sudo mkdir -p /var/lib/crossdesk /var/log/crossdesk
 sudo chown -R $(id -u):$(id -g) /var/lib/crossdesk /var/log/crossdesk
 ```
+
+### 使用域名（EXTERNAL_IP 支持域名）
+
+`EXTERNAL_IP` 既可以是公网 IP（如 `114.114.114.114`），也可以是域名（如 `desk.example.com`）。启用域名时：
+
+- **证书**：启动时自动生成的 TLS 证书会把域名写入 `subjectAltName` 的 `DNS:` 条目（并尽量附带解析出的公网 IP），客户端据此信任该域名，无需再手动信任 IP。
+- **TURN / ICE**：WebRTC 的 ICE 候选地址必须是 IP，因此容器启动时会用 `getent` 把域名解析为 IP，注入 coturn 的 `external-ip`；中继流量仍走该公网 IP。
+- **客户端**：CrossDesk 客户端「自托管服务器配置 → 服务器地址」直接填该域名即可（客户端本就支持域名，会自动 DNS 解析连信令）。
+
+#### 免重建镜像部署（推荐先这样验证）
+
+仓库内置 `docker-compose.yml`，把修改后的 `docker/start.sh` 与 `docker/generate_certs.sh` 直接挂载进官方镜像的固定路径（`/start.sh`、`/docker/generate_certs.sh`），**无需重新构建镜像**即可使用域名能力：
+
+```bash
+# 修改 docker-compose.yml 中的 EXTERNAL_IP / INTERNAL_IP 后
+docker compose up -d
+```
+
+注意：
+
+- 从「仅 IP」切换为「域名」后，需删除已持久化的证书目录（默认 `./crossdesk-data/certs`）再 `up`，才会以 `DNS:` SAN 重新生成证书（`start.sh` 发现证书已存在会跳过生成）。
+- 挂载的脚本文件必须是 **LF 换行**（CRLF 在 Linux 容器内会报 `bad interpreter`）。
+- 若从源码 `docker build` 构建镜像，域名支持已包含在 `docker/start.sh` 与 `docker/generate_certs.sh` 中，正常构建即可。
 
 ## 服务状态接口
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+# CrossDesk-Server —— 免重建镜像部署（EXTERNAL_IP 支持域名）
+#
+# 用法：
+#   1. 按需修改下方的 environment（EXTERNAL_IP / INTERNAL_IP 等）
+#   2. docker compose up -d
+#
+# 原理：
+#   把仓库内已修改后的 docker/start.sh 与 docker/generate_certs.sh 直接挂载进
+#   官方镜像的固定路径（/start.sh、/docker/generate_certs.sh），无需重新构建镜像
+#   即可使用「EXTERNAL_IP 支持域名」的能力。
+#
+# 关键点：
+#   - entrypoint 显式用 /bin/bash 调用 /start.sh，规避 Windows 下挂载文件丢失
+#     可执行位导致的 permission denied。
+#   - EXTERNAL_IP 可填公网 IP（1.2.3.4）或域名（desk.example.com）。填域名时会在
+#     容器启动时经 getent 解析为 IP 注入 coturn 的 external-ip（ICE 仍需 IP）；
+#     证书则以 DNS: 形式写入 SAN。
+#   - 证书在首次启动后持久化到 ./crossdesk-data/certs。若从「仅 IP」切换为「域名」，
+#     需先删除该目录再 up，才会以 DNS: SAN 重新生成证书（start.sh 发现证书已存在会跳过）。
+#   - 挂载的脚本必须是 LF 换行（CRLF 在 Linux 容器内会报 bad interpreter）。
+#
+# 网络说明：
+#   下方为桥接 + 端口映射（兼容 Docker Desktop for Windows/Mac）。
+#   若运行在原生 Linux Docker 且想用 host 网络（与官方 README 一致），可改为：
+#     network_mode: host
+#     # 并删除 ports 段，把 INTERNAL_IP 设为服务器内网 IP（如 10.0.0.1）
+
+services:
+  crossdesk-server:
+    image: crossdesk/crossdesk-server:v1.1.3
+    container_name: crossdesk_server
+    restart: unless-stopped
+    # 显式用 bash 调用挂载进来的 start.sh（绕过挂载文件可执行位丢失的问题）
+    entrypoint: ["/bin/bash", "/start.sh"]
+    environment:
+      EXTERNAL_IP: "desk.example.com"   # 公网 IP(1.2.3.4) 或域名(desk.example.com)
+      INTERNAL_IP: "0.0.0.0"            # 桥接模式下 coturn 监听所有容器接口
+      CROSSDESK_SERVER_PORT: "9099"
+      COTURN_PORT: "3478"
+      MIN_PORT: "50000"
+      MAX_PORT: "60000"
+    ports:
+      - "9099:9099/tcp"                  # 信令 / 管理 HTTPS
+      - "3478:3478/tcp"
+      - "3478:3478/udp"
+      - "50000-60000:50000-60000/udp"    # TURN 媒体端口范围
+    volumes:
+      - ./docker/start.sh:/start.sh
+      - ./docker/generate_certs.sh:/docker/generate_certs.sh
+      - ./crossdesk-data:/var/lib/crossdesk   # 持久化数据库与证书
+      - ./crossdesk-logs:/var/log/crossdesk   # 持久化日志

--- a/docker/generate_certs.sh
+++ b/docker/generate_certs.sh
@@ -3,8 +3,8 @@ set -e
 
 # 检查参数
 if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
-    echo "Usage: $0 <SERVER_IP> [OUTPUT_DIR]"
-    echo "  SERVER_IP: IP address for the certificate"
+    echo "Usage: $0 <SERVER_ADDR> [OUTPUT_DIR]"
+    echo "  SERVER_ADDR: public IP address or domain name for the certificate"
     echo "  OUTPUT_DIR: Directory to save certificates (default: current directory)"
     exit 1
 fi
@@ -29,6 +29,22 @@ SAN_CONF="$OUTPUT_DIR/san.cnf"
 
 # 证书主题
 SUBJ="/C=CN/ST=Zhejiang/L=Hangzhou/O=CrossDesk/OU=CrossDesk/CN=$SERVER_IP"
+
+# Determine whether SERVER_ADDR is an IPv4 address or a domain name, and build
+# the appropriate subjectAltName value. WebRTC/TURN clients validate the cert
+# SAN, so for a domain we emit DNS:<domain> (and also the resolved IP when the
+# domain can be resolved at cert-generation time, so connecting by IP still works).
+if [[ "$SERVER_IP" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+  # Literal IPv4 address
+  SAN_VALUE="IP:$SERVER_IP"
+else
+  # Treat as a domain name / hostname
+  SAN_VALUE="DNS:$SERVER_IP"
+  RESOLVED_IP=$(getent ahostsv4 "$SERVER_IP" 2>/dev/null | awk '{print $1; exit}')
+  if [ -n "$RESOLVED_IP" ]; then
+    SAN_VALUE="$SAN_VALUE,IP:$RESOLVED_IP"
+  fi
+fi
 
 # 1. 生成根证书
 echo "Generating root private key..."
@@ -62,7 +78,7 @@ OU = CrossDesk
 CN = $SERVER_IP
 
 [ req_ext ]
-subjectAltName = IP:$SERVER_IP
+subjectAltName = $SAN_VALUE
 EOL
 
 # 5. 用根证书签发服务器证书（包含 SAN）

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -20,8 +20,29 @@ is_uint() {
 # check environment variables
 if [ -z "$EXTERNAL_IP" ] || [ -z "$INTERNAL_IP" ]; then
   echo "Error: EXTERNAL_IP and INTERNAL_IP must be set."
-  echo "Example: docker run -e EXTERNAL_IP=1.2.3.4 -e INTERNAL_IP=10.0.0.5 crossdesk-server"
+  echo "EXTERNAL_IP may be a public IP (e.g. 1.2.3.4) or a domain name (e.g. desk.example.com)."
+  echo "Example: docker run -e EXTERNAL_IP=desk.example.com -e INTERNAL_IP=10.0.0.5 crossdesk-server"
   exit 1
+fi
+
+# Resolve EXTERNAL_IP to a literal IPv4 address for coturn's external-ip.
+# WebRTC ICE candidates require an IP, not a domain, so if EXTERNAL_IP is a
+# domain name we resolve it once at startup via getent (glibc, always present
+# on the ubuntu:22.04 base image). The original value is still passed to
+# generate_certs.sh so the certificate gets a DNS: SAN for the domain.
+is_ipv4() {
+  [[ "$1" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]
+}
+
+if is_ipv4 "$EXTERNAL_IP"; then
+  EXTERNAL_IP_RESOLVED="$EXTERNAL_IP"
+else
+  EXTERNAL_IP_RESOLVED=$(getent ahostsv4 "$EXTERNAL_IP" 2>/dev/null | awk '{print $1; exit}')
+  if [ -z "$EXTERNAL_IP_RESOLVED" ]; then
+    echo "Error: Unable to resolve EXTERNAL_IP domain '$EXTERNAL_IP' to an IPv4 address."
+    exit 1
+  fi
+  echo "Resolved EXTERNAL_IP domain '$EXTERNAL_IP' -> '$EXTERNAL_IP_RESOLVED'"
 fi
 
 if [ -z "$COTURN_PORT" ]; then
@@ -82,7 +103,7 @@ cat > "$CONF_FILE" <<EOF
 # coturn auto-generated configuration
 listening-port=${COTURN_PORT}
 listening-ip=${INTERNAL_IP}
-external-ip=${EXTERNAL_IP}
+external-ip=${EXTERNAL_IP_RESOLVED}
 min-port=${MIN_PORT}
 max-port=${MAX_PORT}
 verbose


### PR DESCRIPTION
- docker/start.sh: resolve EXTERNAL_IP (domain) to an IPv4 address at startup via getent for coturn external-ip; pass the original value to certificate generation so the cert keeps the domain.
- docker/generate_certs.sh: emit DNS: SAN for a domain (plus the resolved IP when resolvable), and IP: SAN for an IPv4 address.
- docker-compose.yml: mount the modified scripts into the official image so domain support works without rebuilding the image.
- README.md: document domain support and the no-rebuild deployment.
- .gitattributes: force LF line endings for the shell scripts so they run correctly inside the Linux container.